### PR TITLE
Apply UITextAutocapitalizationType.none to Email fields

### DIFF
--- a/HomeBugh/LoginView.swift
+++ b/HomeBugh/LoginView.swift
@@ -94,6 +94,7 @@ struct EmailTextField: View {
             .cornerRadius(5.0)
             .padding(.bottom, 20)
             .keyboardType(.emailAddress)
+            .autocapitalization(.none)
     }
 }
 

--- a/HomeBugh/SignUpView.swift
+++ b/HomeBugh/SignUpView.swift
@@ -83,6 +83,7 @@ struct SUEmailTextField: View {
             .cornerRadius(5.0)
             .padding(.bottom, 20)
             .keyboardType(.emailAddress)
+            .autocapitalization(.none)
     }
 }
 


### PR DESCRIPTION
Added autocapitalization instruction on the email fields in Login and SignUp views.